### PR TITLE
Add homepage, Shabby dependency to PerSaveScreenshots

### DIFF
--- a/NetKAN/PerSaveScreenshots.netkan
+++ b/NetKAN/PerSaveScreenshots.netkan
@@ -1,13 +1,11 @@
-spec_version: v1.4
+spec_version: v1.27
 identifier: PerSaveScreenshots
 $kref: '#/ckan/github/DeltaDizzy/PerSaveScreenshots'
-ksp_version: 1.12
-license: MIT
 resources:
   homepage: https://forum.kerbalspaceprogram.com/topic/219192-*
 tags:
   - plugin
   - convenience
-install:
-  - file: GameData/PerSaveScreenshots.dll
-    install_to: GameData/PerSaveScreenshots
+ksp_version: '1.12'
+depends:
+  - name: Shabby


### PR DESCRIPTION
A release using the Shabby dependency will be out within a day or two, but I don't think any issues would be caused by people picking up the new dependency early? NetKAN updates were generated via the webtool.